### PR TITLE
Copy manifest.json only if it exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,24 +43,20 @@
   - [preact-router]
   - 1.5kb of conditionally-loaded polyfills for [fetch] & [Promise]
 
-### Installation
+### Requirements
 
-> **Important**: [Node.js](https://nodejs.org/en/) > V8.x is a minimum requirement.
-
-```sh
-$ npm install -g preact-cli
-```
+> **Important**: [Node.js](https://nodejs.org/en/) > V8.x and npm 5.2+ is a minimum requirement.
 
 ### Usage
 
 ```sh
-$ preact create <template-name> <project-name>
+$ npx preact-cli create <template-name> <project-name>
 ```
 
 Example:
 
 ```sh
-$ preact create default my-project
+$ npx preact-cli create default my-project
 ```
 
 The above command pulls the template from [preactjs-templates/default], prompts for some information, and generates the project at `./my-project/`.

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
 	"lerna": "3.13.1",
-	"version": "3.0.0",
+	"version": "3.0.1",
 	"packages": ["packages/*"],
 	"npmClient": "yarn",
 	"useWorkspaces": true

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
 	"lerna": "3.13.1",
-	"version": "3.0.0-rc.9",
+	"version": "3.0.0",
 	"packages": ["packages/*"],
 	"npmClient": "yarn",
 	"useWorkspaces": true

--- a/packages/async-loader/package.json
+++ b/packages/async-loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@preact/async-loader",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Preact's async component loader for Webpack",
   "files": [
     "*.js"

--- a/packages/cli/lib/lib/webpack/webpack-client-config.js
+++ b/packages/cli/lib/lib/webpack/webpack-client-config.js
@@ -98,18 +98,7 @@ async function clientConfig(env) {
 			...getBabelEsmPlugin(env),
 			new CopyWebpackPlugin(
 				[
-					...(existsSync(source('manifest.json'))
-						? [{ from: 'manifest.json' }]
-						: [
-								{
-									from: resolve(__dirname, '../../resources/manifest.json'),
-									to: 'manifest.json',
-								},
-								{
-									from: resolve(__dirname, '../../resources/icon.png'),
-									to: 'assets/icon.png',
-								},
-						  ]),
+					existsSync(source('manifest.json')) && { from: 'manifest.json' },
 					// copy any static files
 					existsSync(source('assets')) && { from: 'assets', to: 'assets' },
 					// copy sw-debug

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "preact-cli",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Start building a Preact Progressive Web App in seconds.",
   "repository": "preactjs/preact-cli",
   "main": "lib/index.js",
@@ -78,7 +78,7 @@
     "@babel/plugin-transform-react-jsx": "^7.9.0",
     "@babel/preset-env": "^7.9.0",
     "@babel/preset-typescript": "^7.9.0",
-    "@preact/async-loader": "^3.0.0",
+    "@preact/async-loader": "^3.0.1",
     "@prefresh/webpack": "^0.8.1",
     "autoprefixer": "^9.6.0",
     "babel-esm-plugin": "^0.9.0",

--- a/packages/prerender-data-provider/package.json
+++ b/packages/prerender-data-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@preact/prerender-data-provider",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Prerender Prerender data provider for preact-cli apps",
   "keywords": [
     "preact",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

Bugfix

**Did you add tests for your changes?**

No

**Summary**

This change makes sure `manifest.json` is copied in `build` only if it exists in `src`. 
This prevents boilerplate manifest and icon to be copied over in the case when user moves `manifest.json` somewhere else (like `assets` or `static`). 
Since almost all templates (sans widget I think) come with predefined manifest that at least populates correct project name, if that manifest is removed I would assume it's on purpose and should not be replaced with boilerplate "preact app" one.

**Does this PR introduce a breaking change?**

No

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**

Please paste the results of `preact info` here.
